### PR TITLE
Onbly chose one random directory

### DIFF
--- a/modules/file.php
+++ b/modules/file.php
@@ -340,11 +340,9 @@ function wpcf7_init_uploads() {
 }
 
 function wpcf7_maybe_add_random_dir( $dir ) {
-	do {
-		$rand_max = mt_getrandmax();
-		$rand = zeroise( mt_rand( 0, $rand_max ), strlen( $rand_max ) );
-		$dir_new = path_join( $dir, $rand );
-	} while ( file_exists( $dir_new ) );
+	$rand_max = mt_getrandmax();
+	$rand = zeroise( mt_rand( 0, $rand_max ), strlen( $rand_max ) );
+	$dir_new = path_join( $dir, $rand );
 
 	if ( wp_mkdir_p( $dir_new ) ) {
 		return $dir_new;


### PR DESCRIPTION
No need for the recursion, this breaks on S3 where file_exists will always return true for directoies.